### PR TITLE
feat: add tag filters and org names

### DIFF
--- a/src/components/example.astro
+++ b/src/components/example.astro
@@ -1,10 +1,13 @@
 ---
 import { Image } from "astro:assets";
 
-const { tag, url, title, img, description, index } = Astro.props;
+import Tag from "./tag.astro";
+import { tagClass } from "../utils/tags";
+
+const { tags, url, title, org, img, description, index } = Astro.props;
 ---
 
-<div>
+<div class={`example ${tags.map((tag: string) => tagClass(tag)).join(" ")}`}>
   <a href={url}>
     <div class="exampleContainer">
       <div class="exampleImageContainer">
@@ -14,10 +17,13 @@ const { tag, url, title, img, description, index } = Astro.props;
           alt=""
           loading={index < 2 ? "eager" : "lazy"}
         />
-        <span class="tag">{tag}</span>
       </div>
 
       <div class="exampleText">
+        <p class="org">
+          {org}
+        </p>
+
         <h2>
           {title}
         </h2>
@@ -25,6 +31,8 @@ const { tag, url, title, img, description, index } = Astro.props;
         <p class="description">
           {description}
         </p>
+
+        {tags.map((tag: string) => <Tag tag={tag} />)}
       </div>
     </div>
   </a>
@@ -39,24 +47,6 @@ const { tag, url, title, img, description, index } = Astro.props;
     text-decoration: underline;
   }
 
-  .tag {
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    color: rgb(50, 50, 50);
-    text-transform: uppercase;
-    font-size: 12px;
-    padding: 3px 5px;
-    border-radius: 2px;
-    text-decoration: none;
-    border: 1px solid rgb(150, 150, 150);
-    background-color: white;
-  }
-
-  a:hover .tag {
-    background-color: rgb(241, 241, 232);
-  }
-
   .exampleContainer {
     /* border: 1px solid rgb(200,200,200); */
     margin-bottom: 5px;
@@ -66,7 +56,7 @@ const { tag, url, title, img, description, index } = Astro.props;
     width: 100%;
     padding: 1%;
     background-color: white;
-    border-radius: 2px;
+    border-radius: 5px;
     margin-bottom: 15px;
     border: 1px solid rgb(200, 200, 200);
   }
@@ -93,6 +83,7 @@ const { tag, url, title, img, description, index } = Astro.props;
     object-position: left center;
     width: 100%;
     height: 100%;
+    border-radius: 5px;
   }
 
   a:hover .exampleImage {
@@ -125,6 +116,13 @@ const { tag, url, title, img, description, index } = Astro.props;
     content: "";
     display: table;
     clear: both;
+  }
+
+  .org {
+    font-size: 14px;
+    color: rgb(100, 100, 100);
+    margin-top: 5px;
+    margin-bottom: 5px;
   }
 
   .description {

--- a/src/components/examples.astro
+++ b/src/components/examples.astro
@@ -1,10 +1,20 @@
 ---
+import type { CollectionEntry } from "astro:content";
 import Example from "./example.astro";
+import Tag from "./tag.astro";
 
 const { examples } = Astro.props;
 ---
 
 <div class="examples">
+  <div class="tags">
+    {
+      [...new Set(examples.flatMap((data: any, i: number) => data.tags))].map(
+        (tag: string) => <Tag tag={tag} />
+      )
+    }
+  </div>
+
   {examples.map((data: any, i: number) => <Example {...data} index={i} />)}
 </div>
 
@@ -23,6 +33,10 @@ const { examples } = Astro.props;
     clear: both;
   }
 
+  .tags {
+    margin-bottom: 10px;
+  }
+
   @media (max-width: 650px) {
     .examples {
       margin-left: 25px;
@@ -31,3 +45,36 @@ const { examples } = Astro.props;
     }
   }
 </style>
+
+<script>
+  import { tagClass } from "../utils/tags.ts";
+
+  const tags = document.querySelectorAll(".tag");
+
+  tags.forEach((tag) => {
+    tag.addEventListener("click", (event: Event) => {
+      event.preventDefault();
+
+      const target = event.target;
+      if (target && "textContent" in target) {
+        const tag = String(target.textContent);
+
+        document.querySelectorAll(`.tag`).forEach((el) => {
+          if (el.classList.contains(tagClass(tag))) {
+            el.classList.add("active");
+          } else {
+            el.classList.remove("active");
+          }
+        });
+
+        document.querySelectorAll(".example").forEach((el) => {
+          if (el.classList.contains(tagClass(tag))) {
+            el.classList.remove("hidden");
+          } else {
+            el.classList.add("hidden");
+          }
+        });
+      }
+    });
+  });
+</script>

--- a/src/components/tag.astro
+++ b/src/components/tag.astro
@@ -1,0 +1,29 @@
+---
+import { tagClass } from "../utils/tags.ts";
+
+const { tag } = Astro.props;
+---
+
+<span class={`tag ${tagClass(tag)}`}>{tag}</span>
+
+<style>
+  .tag {
+    display: inline-block;
+    color: rgb(50, 50, 50);
+    text-transform: uppercase;
+    font-size: 12px;
+    padding: 3px 5px;
+    border-radius: 2px;
+    text-decoration: none;
+    border: 1px solid rgb(150, 150, 150);
+    background-color: white;
+    margin-right: 5px;
+    margin-top: 3px;
+    margin-bottom: 3px;
+    cursor: pointer;
+  }
+
+  .tag:hover {
+    background-color: rgb(241, 241, 232);
+  }
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -5,7 +5,8 @@ const exampleCollection = defineCollection({
     schema: ({ image }) =>
         z.object({
             title: z.string(),
-            tag: z.string(),
+            org: z.string(),
+            tags: z.array(z.string()),
             img: image(),
             description: z.string(),
             url: z.string().url(),

--- a/src/content/examples/2020-fundraising.md
+++ b/src/content/examples/2020-fundraising.md
@@ -1,6 +1,8 @@
 ---
 title: What first-quarter fundraising can tell us about 2020
-tag: data processing & analysis
+org: FiveThirtyEight
+tags:
+    - data processing & analysis
 description: >-
     To show the state of presidential money, crunched the data behind this
     graphics story designed and developed by Julia Wolfe of FiveThirtyEight.

--- a/src/content/examples/2022-election-results.md
+++ b/src/content/examples/2022-election-results.md
@@ -1,10 +1,12 @@
 ---
 title: "2022 election results"
-tag: data processing and visualization
+org: The Washington Post
+tags:
+    - data processing & analysis
 description: >-
     For the midterm elections, I built scrapers to power live election night predictions,
     visualized model results, contributed to data pipelines, analyzed FEC data and
-    prototyped and refined a find-your-district personalization feature.
+    prototyped and helped refine a find-your-district personalization feature.
 img: ./img/findyourdistrict.png
 url: https://www.washingtonpost.com/election-results/2022/house/
 date: 2022-11-08

--- a/src/content/examples/abandoned-in-america.md
+++ b/src/content/examples/abandoned-in-america.md
@@ -1,6 +1,8 @@
 ---
 title: Abandoned in America
-tag: design & graphics
+org: Center for Public Integrity
+tags:
+    - graphics & design
 description: >-
     This was an ambitious multi-part series on the places and people with
     little political clout. Designed and developed the presentation, as well as overseeing data analysis

--- a/src/content/examples/death-in-the-trench.md
+++ b/src/content/examples/death-in-the-trench.md
@@ -1,6 +1,8 @@
 ---
 title: Death in the Trench
-tag: story design
+org: Center for Public Integrity
+tags:
+    - graphics & design
 description: >-
     Designed the presentation for this striking story on a preventable death and what it says about workplace safety enforcement.
 img: ./img/trench.png

--- a/src/content/examples/laid-off.md
+++ b/src/content/examples/laid-off.md
@@ -1,6 +1,10 @@
 ---
 title: "Laid off: 5 million jobs and counting"
-tag: data processing and graphics
+org: Big Local News
+tags:
+    - data processing & analysis
+    - graphics & design
+    - fun
 description: >-
     For fun, built this interactive graphic to showcase data collected by an open source Big Local News
     project to scrape layoff notices from all 50 states. Contributed open source scrapers to the project

--- a/src/content/examples/pdf-parser.md
+++ b/src/content/examples/pdf-parser.md
@@ -1,6 +1,8 @@
 ---
 title: Public financial disclosure parser
-tag: data processing
+org: Center for Public Integrity
+tags:
+    - data processing & analysis
 description: >-
     Built a tool that helped newsrooms compile databases of Trump officials' financial histories. This was
     used to report a daily story by the New York Times, to build ProPublica's Trump Town

--- a/src/content/examples/point-to-ukraine.md
+++ b/src/content/examples/point-to-ukraine.md
@@ -1,6 +1,8 @@
 ---
 title: Can you point to Ukraine on a map?
-tag: fun
+org: Personal project
+tags:
+    - fun
 description: >-
     Created a quick Serverless API and Observable notebook for this interactive
     knowledge test which asked users to point to Ukraine after a cabinet secretary

--- a/src/content/examples/reno-map.md
+++ b/src/content/examples/reno-map.md
@@ -1,6 +1,8 @@
 ---
 title: "He Tore Down Motels Where Poor Residents Lived During a Housing Crisis"
-tag: map
+org: ProPublica
+tags:
+    - graphics & design
 description: >-
     Designed and developed a scrollytelling map of the properties bought by a Reno developer for
     this ProPublica investigative project.

--- a/src/content/examples/ross-ships.md
+++ b/src/content/examples/ross-ships.md
@@ -1,9 +1,12 @@
 ---
 title: Wilbur Ross will shepherd Trump’s trade policy. He also owns ships.
+org: Center for Public Integrity
 description: >-
     Built a map using Mapbox.js to display millions of ship locations collected by satellites, found a cabinet secretary's
     shipping firm docked in Iran at the height of sanctions, designed graphics for the resulting story.
-tag: analysis & graphics
+tags:
+    - data processing & analysis
+    - graphics & design
 img: ./img/ross.png
 url: https://archive.publicintegrity.org/politics/wilbur-ross-will-shepherd-trumps-trade-policy-should-he-also-own-a-shipping-firm/
 date: 2017-03-23

--- a/src/content/examples/stat-app.md
+++ b/src/content/examples/stat-app.md
@@ -1,6 +1,8 @@
 ---
 title: "STAT News"
-tag: mobile app
+org: STAT
+tags:
+    - apps
 description: >-
     For STAT, built a mobile app for iOS and Android to showcase their stories and better engage
     mobile readers. The app lets readers follow their favorite topics and reporters, save stories

--- a/src/content/examples/state-leg-financial-interests.md
+++ b/src/content/examples/state-leg-financial-interests.md
@@ -1,6 +1,8 @@
 ---
 title: Find your state legislators' financial interests
-tag: app
+org: Center for Public Integrity
+tags:
+    - apps
 description: >-
     Helped a reporting team collect, track and input data from nearly every state legislator's financial disclosure in the country,
     then built an app using DocumentCloud to search and view the disclosures.

--- a/src/content/examples/suggested-poems.md
+++ b/src/content/examples/suggested-poems.md
@@ -1,6 +1,8 @@
 ---
 title: Suggested poems for Gmail
-tag: fun
+org: Personal project
+tags:
+    - fun
 description: >-
     Released on April Fools' Day 2020, this browser extension replaced Gmail’s
     Smart Replies with lines of poetry. It was enjoyed by many, including

--- a/src/content/examples/vacuum-pacs.md
+++ b/src/content/examples/vacuum-pacs.md
@@ -1,6 +1,9 @@
 ---
 title: You donated to kids with cancer. This Vegas telemarketer cashed in.
-tag: graphics & analysis
+org: Center for Public Integrity
+tags:
+    - graphics & design
+    - data processing & analysis
 description: >-
     Analyzed a universe of PACs that raised from
     small-dollar donors and spent mostly on themselves. Zeroed into one telemarketer's

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,7 +3,7 @@ import "@fontsource/open-sans/latin-400.css";
 import "@fontsource/open-sans/latin-700.css";
 
 interface Props {
-	title: string;
+  title: string;
 }
 
 const { title } = Astro.props;
@@ -11,32 +11,41 @@ const { title } = Astro.props;
 
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="description" content="A developer, designer and journalist" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" type="image/png" href="/favicon.png">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="A developer, designer and journalist" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
 
-		<meta name="generator" content={Astro.generator} />
-		<title>{title}</title>
-	</head>
-	<body>
-		<slot />
-	</body>
+    <meta name="generator" content={Astro.generator} />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
 </html>
 <style is:global>
-    @import url('../../node_modules/font-awesome/css/font-awesome.min.css');
+  @import url("../../node_modules/font-awesome/css/font-awesome.min.css");
 
-    body, html {
-        margin: 0;
-        padding: 0;
-        font-family: 'Open Sans', sans-serif;
-        background-color: rgb(241, 240, 239);
-    }
+  body,
+  html {
+    margin: 0;
+    padding: 0;
+    font-family: "Open Sans", sans-serif;
+    background-color: rgb(241, 240, 239);
+  }
 
-    @media (max-width: 650px) {
-        body {
-            font-size: 70%;
-        }
+  .hidden {
+    display: none;
+  }
+
+  .active {
+    background-color: rgb(241, 241, 232) !important;
+  }
+
+  @media (max-width: 650px) {
+    body {
+      font-size: 70%;
     }
+  }
 </style>

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,0 +1,3 @@
+export function tagClass(tag: string) {
+    return `tag-${tag.replace(/[ &]+/g, "-")}`;
+}


### PR DESCRIPTION
Adds org names and some interactive filtering for tags:

<img width="658" alt="Screenshot 2024-03-07 at 7 07 26 PM" src="https://github.com/chriszs/zubak-skees.dev/assets/1103467/17d8c7fc-cd6f-483d-af5f-5ad6cd7ba765">

Consolidates tags into fewer groupings.

Hopefully allows users to focus in on a particular facet of my work that's of particular interest to them and make better sense of where I concentrate my professional attention.